### PR TITLE
Add copyright notice to RogueCoreIDF sources

### DIFF
--- a/RogueCoreIDF/components/rk_cfgd/include/rk_cfgd.h
+++ b/RogueCoreIDF/components/rk_cfgd/include/rk_cfgd.h
@@ -1,3 +1,6 @@
+/* Copyright (c) 2024 Donavin Rediron.
+ * All rights reserved. Usage without written permission is prohibited. */
+
 #pragma once
 #include <stddef.h>
 #include "esp_err.h"

--- a/RogueCoreIDF/components/rk_cfgd/rk_cfg_schema.h
+++ b/RogueCoreIDF/components/rk_cfgd/rk_cfg_schema.h
@@ -1,3 +1,6 @@
+/* Copyright (c) 2024 Donavin Rediron.
+ * All rights reserved. Usage without written permission is prohibited. */
+
 #pragma once
 #define RK_CFG_KEY_WIFI_SSID      "wifi.ssid"
 #define RK_CFG_KEY_WIFI_PSK       "wifi.psk"

--- a/RogueCoreIDF/components/rk_cfgd/rk_cfgd.c
+++ b/RogueCoreIDF/components/rk_cfgd/rk_cfgd.c
@@ -1,3 +1,6 @@
+/* Copyright (c) 2024 Donavin Rediron.
+ * All rights reserved. Usage without written permission is prohibited. */
+
 #include "rk_cfgd.h"
 #include "rk_cfg_schema.h"
 #include "nvs_flash.h"

--- a/RogueCoreIDF/components/rk_fsd/include/rk_fsd.h
+++ b/RogueCoreIDF/components/rk_fsd/include/rk_fsd.h
@@ -1,3 +1,6 @@
+/* Copyright (c) 2024 Donavin Rediron.
+ * All rights reserved. Usage without written permission is prohibited. */
+
 #pragma once
 #include <stddef.h>
 #include "esp_err.h"

--- a/RogueCoreIDF/components/rk_fsd/rk_fsd.c
+++ b/RogueCoreIDF/components/rk_fsd/rk_fsd.c
@@ -1,3 +1,6 @@
+/* Copyright (c) 2024 Donavin Rediron.
+ * All rights reserved. Usage without written permission is prohibited. */
+
 #include "rk_fsd.h"
 #include "esp_littlefs.h"
 #include <dirent.h>

--- a/RogueCoreIDF/components/rk_hal/include/rk_hal.h
+++ b/RogueCoreIDF/components/rk_hal/include/rk_hal.h
@@ -1,3 +1,6 @@
+/* Copyright (c) 2024 Donavin Rediron.
+ * All rights reserved. Usage without written permission is prohibited. */
+
 #pragma once
 #include <stddef.h>
 #include "esp_err.h"

--- a/RogueCoreIDF/components/rk_hal/rk_gpio.c
+++ b/RogueCoreIDF/components/rk_hal/rk_gpio.c
@@ -1,3 +1,6 @@
+/* Copyright (c) 2024 Donavin Rediron.
+ * All rights reserved. Usage without written permission is prohibited. */
+
 #include "rk_hal.h"
 
 esp_err_t rk_gpio_init(gpio_num_t pin, gpio_mode_t mode)

--- a/RogueCoreIDF/components/rk_hal/rk_i2c.c
+++ b/RogueCoreIDF/components/rk_hal/rk_i2c.c
@@ -1,3 +1,6 @@
+/* Copyright (c) 2024 Donavin Rediron.
+ * All rights reserved. Usage without written permission is prohibited. */
+
 #include "rk_hal.h"
 
 esp_err_t rk_i2c_init(i2c_port_t port)

--- a/RogueCoreIDF/components/rk_hal/rk_spi.c
+++ b/RogueCoreIDF/components/rk_hal/rk_spi.c
@@ -1,3 +1,6 @@
+/* Copyright (c) 2024 Donavin Rediron.
+ * All rights reserved. Usage without written permission is prohibited. */
+
 #include "rk_hal.h"
 
 esp_err_t rk_spi_init(spi_host_device_t host)

--- a/RogueCoreIDF/components/rk_hal/rk_timer.c
+++ b/RogueCoreIDF/components/rk_hal/rk_timer.c
@@ -1,3 +1,6 @@
+/* Copyright (c) 2024 Donavin Rediron.
+ * All rights reserved. Usage without written permission is prohibited. */
+
 #include "rk_hal.h"
 
 esp_err_t rk_timer_init(timer_group_t group, timer_idx_t idx, uint64_t alarm_us)

--- a/RogueCoreIDF/components/rk_hal/rk_uart.c
+++ b/RogueCoreIDF/components/rk_hal/rk_uart.c
@@ -1,3 +1,6 @@
+/* Copyright (c) 2024 Donavin Rediron.
+ * All rights reserved. Usage without written permission is prohibited. */
+
 #include "rk_hal.h"
 
 esp_err_t rk_uart_init(int port, int tx_pin, int rx_pin, int baud)

--- a/RogueCoreIDF/components/rk_kernel/include/rk_kernel.h
+++ b/RogueCoreIDF/components/rk_kernel/include/rk_kernel.h
@@ -1,3 +1,6 @@
+/* Copyright (c) 2024 Donavin Rediron.
+ * All rights reserved. Usage without written permission is prohibited. */
+
 #pragma once
 #include <stdbool.h>
 #include "freertos/FreeRTOS.h"

--- a/RogueCoreIDF/components/rk_kernel/rk_event.c
+++ b/RogueCoreIDF/components/rk_kernel/rk_event.c
@@ -1,3 +1,6 @@
+/* Copyright (c) 2024 Donavin Rediron.
+ * All rights reserved. Usage without written permission is prohibited. */
+
 #include "rk_kernel.h"
 
 rk_event_t rk_event_create(void)

--- a/RogueCoreIDF/components/rk_kernel/rk_ipc.c
+++ b/RogueCoreIDF/components/rk_kernel/rk_ipc.c
@@ -1,3 +1,6 @@
+/* Copyright (c) 2024 Donavin Rediron.
+ * All rights reserved. Usage without written permission is prohibited. */
+
 #include "rk_kernel.h"
 
 rk_msgq_t rk_msgq_create(size_t capacity, size_t msg_size)

--- a/RogueCoreIDF/components/rk_kernel/rk_panic.c
+++ b/RogueCoreIDF/components/rk_kernel/rk_panic.c
@@ -1,3 +1,6 @@
+/* Copyright (c) 2024 Donavin Rediron.
+ * All rights reserved. Usage without written permission is prohibited. */
+
 #include <stdio.h>
 #include "rk_kernel.h"
 #include "esp_system.h"

--- a/RogueCoreIDF/components/rk_kernel/rk_task.c
+++ b/RogueCoreIDF/components/rk_kernel/rk_task.c
@@ -1,3 +1,6 @@
+/* Copyright (c) 2024 Donavin Rediron.
+ * All rights reserved. Usage without written permission is prohibited. */
+
 #include "rk_kernel.h"
 
 rk_task_t rk_task_spawn(const char *name, TaskFunction_t entry, void *arg,

--- a/RogueCoreIDF/components/rk_log/include/rk_log.h
+++ b/RogueCoreIDF/components/rk_log/include/rk_log.h
@@ -1,3 +1,6 @@
+/* Copyright (c) 2024 Donavin Rediron.
+ * All rights reserved. Usage without written permission is prohibited. */
+
 #pragma once
 #include <stdarg.h>
 #include "esp_err.h"

--- a/RogueCoreIDF/components/rk_log/rk_log.c
+++ b/RogueCoreIDF/components/rk_log/rk_log.c
@@ -1,3 +1,6 @@
+/* Copyright (c) 2024 Donavin Rediron.
+ * All rights reserved. Usage without written permission is prohibited. */
+
 #include "rk_log.h"
 #include <stdio.h>
 #include <string.h>

--- a/RogueCoreIDF/components/rk_netd/include/rk_netd.h
+++ b/RogueCoreIDF/components/rk_netd/include/rk_netd.h
@@ -1,3 +1,6 @@
+/* Copyright (c) 2024 Donavin Rediron.
+ * All rights reserved. Usage without written permission is prohibited. */
+
 #pragma once
 #include "esp_err.h"
 

--- a/RogueCoreIDF/components/rk_netd/rk_sntp.c
+++ b/RogueCoreIDF/components/rk_netd/rk_sntp.c
@@ -1,3 +1,6 @@
+/* Copyright (c) 2024 Donavin Rediron.
+ * All rights reserved. Usage without written permission is prohibited. */
+
 #include "rk_netd.h"
 #include "rk_cfgd.h"
 #include "rk_cfg_schema.h"

--- a/RogueCoreIDF/components/rk_netd/rk_wifi.c
+++ b/RogueCoreIDF/components/rk_netd/rk_wifi.c
@@ -1,3 +1,6 @@
+/* Copyright (c) 2024 Donavin Rediron.
+ * All rights reserved. Usage without written permission is prohibited. */
+
 #include "rk_netd.h"
 #include "rk_cfgd.h"
 #include "rk_log.h"

--- a/RogueCoreIDF/components/rk_otad/include/rk_otad.h
+++ b/RogueCoreIDF/components/rk_otad/include/rk_otad.h
@@ -1,3 +1,6 @@
+/* Copyright (c) 2024 Donavin Rediron.
+ * All rights reserved. Usage without written permission is prohibited. */
+
 #pragma once
 #include "esp_err.h"
 

--- a/RogueCoreIDF/components/rk_otad/rk_otad.c
+++ b/RogueCoreIDF/components/rk_otad/rk_otad.c
@@ -1,3 +1,6 @@
+/* Copyright (c) 2024 Donavin Rediron.
+ * All rights reserved. Usage without written permission is prohibited. */
+
 #include "rk_otad.h"
 #include "esp_https_ota.h"
 #include "esp_log.h"

--- a/RogueCoreIDF/components/rk_shell/include/rk_shell.h
+++ b/RogueCoreIDF/components/rk_shell/include/rk_shell.h
@@ -1,3 +1,6 @@
+/* Copyright (c) 2024 Donavin Rediron.
+ * All rights reserved. Usage without written permission is prohibited. */
+
 #pragma once
 #ifdef __cplusplus
 extern "C" {

--- a/RogueCoreIDF/components/rk_shell/rk_shell.c
+++ b/RogueCoreIDF/components/rk_shell/rk_shell.c
@@ -1,3 +1,6 @@
+/* Copyright (c) 2024 Donavin Rediron.
+ * All rights reserved. Usage without written permission is prohibited. */
+
 #include "rk_shell.h"
 #include "rk_hal.h"
 #include "rk_kernel.h"

--- a/RogueCoreIDF/components/rk_shell/rk_shell_cmds.c
+++ b/RogueCoreIDF/components/rk_shell/rk_shell_cmds.c
@@ -1,3 +1,6 @@
+/* Copyright (c) 2024 Donavin Rediron.
+ * All rights reserved. Usage without written permission is prohibited. */
+
 #include "rk_shell.h"
 #include "rk_cfgd.h"
 #include "rk_cfg_schema.h"

--- a/RogueCoreIDF/components/rk_tests/test_cfgd.c
+++ b/RogueCoreIDF/components/rk_tests/test_cfgd.c
@@ -1,3 +1,6 @@
+/* Copyright (c) 2024 Donavin Rediron.
+ * All rights reserved. Usage without written permission is prohibited. */
+
 #include "unity.h"
 #include "rk_cfgd.h"
 

--- a/RogueCoreIDF/components/rk_tests/test_fsd.c
+++ b/RogueCoreIDF/components/rk_tests/test_fsd.c
@@ -1,3 +1,6 @@
+/* Copyright (c) 2024 Donavin Rediron.
+ * All rights reserved. Usage without written permission is prohibited. */
+
 #include "unity.h"
 #include "rk_fsd.h"
 

--- a/RogueCoreIDF/components/rk_tests/test_hal.c
+++ b/RogueCoreIDF/components/rk_tests/test_hal.c
@@ -1,3 +1,6 @@
+/* Copyright (c) 2024 Donavin Rediron.
+ * All rights reserved. Usage without written permission is prohibited. */
+
 #include "unity.h"
 #include "rk_hal.h"
 

--- a/RogueCoreIDF/components/rk_tests/test_netd.c
+++ b/RogueCoreIDF/components/rk_tests/test_netd.c
@@ -1,3 +1,6 @@
+/* Copyright (c) 2024 Donavin Rediron.
+ * All rights reserved. Usage without written permission is prohibited. */
+
 #include "unity.h"
 #include "rk_netd.h"
 

--- a/RogueCoreIDF/main/app_main.c
+++ b/RogueCoreIDF/main/app_main.c
@@ -1,3 +1,6 @@
+/* Copyright (c) 2024 Donavin Rediron.
+ * All rights reserved. Usage without written permission is prohibited. */
+
 #include "rc_init.h"
 #include "rk_cfgd.h"
 #include "rk_log.h"

--- a/RogueCoreIDF/main/rc_init.c
+++ b/RogueCoreIDF/main/rc_init.c
@@ -1,3 +1,6 @@
+/* Copyright (c) 2024 Donavin Rediron.
+ * All rights reserved. Usage without written permission is prohibited. */
+
 #include "rc_init.h"
 #include "rk_log.h"
 #include "rk_cfgd.h"

--- a/RogueCoreIDF/main/rc_init.h
+++ b/RogueCoreIDF/main/rc_init.h
@@ -1,3 +1,6 @@
+/* Copyright (c) 2024 Donavin Rediron.
+ * All rights reserved. Usage without written permission is prohibited. */
+
 #pragma once
 
 #ifdef __cplusplus


### PR DESCRIPTION
## Summary
- add copyright notice to all C and header files in RogueCoreIDF

## Testing
- `idf.py build` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_689d6862fa888332907746208f607d6b